### PR TITLE
[bug fix] Bind the interceptor instance to used method.

### DIFF
--- a/src/baseService.ts
+++ b/src/baseService.ts
@@ -288,7 +288,10 @@ class HttpClient {
 
     builder.requestInterceptors.forEach((interceptor) => {
       if (interceptor instanceof RequestInterceptor) {
-        this.axios.interceptors.request.use(interceptor.onFulfilled.bind(interceptor), interceptor.onRejected.bind(interceptor));
+        this.axios.interceptors.request.use(
+          interceptor.onFulfilled.bind(interceptor),
+          interceptor.onRejected.bind(interceptor),
+        );
       } else {
         this.axios.interceptors.request.use(interceptor);
       }
@@ -296,7 +299,10 @@ class HttpClient {
 
     builder.responseInterceptors.forEach((interceptor) => {
       if (interceptor instanceof ResponseInterceptor) {
-        this.axios.interceptors.response.use(interceptor.onFulfilled.bind(interceptor), interceptor.onRejected.bind(interceptor));
+        this.axios.interceptors.response.use(
+          interceptor.onFulfilled.bind(interceptor),
+          interceptor.onRejected.bind(interceptor),
+        );
       } else {
         this.axios.interceptors.response.use(interceptor);
       }

--- a/src/baseService.ts
+++ b/src/baseService.ts
@@ -288,7 +288,7 @@ class HttpClient {
 
     builder.requestInterceptors.forEach((interceptor) => {
       if (interceptor instanceof RequestInterceptor) {
-        this.axios.interceptors.request.use(interceptor.onFulfilled, interceptor.onRejected);
+        this.axios.interceptors.request.use(interceptor.onFulfilled.bind(interceptor), interceptor.onRejected.bind(interceptor));
       } else {
         this.axios.interceptors.request.use(interceptor);
       }
@@ -296,7 +296,7 @@ class HttpClient {
 
     builder.responseInterceptors.forEach((interceptor) => {
       if (interceptor instanceof ResponseInterceptor) {
-        this.axios.interceptors.response.use(interceptor.onFulfilled, interceptor.onRejected);
+        this.axios.interceptors.response.use(interceptor.onFulfilled.bind(interceptor), interceptor.onRejected.bind(interceptor));
       } else {
         this.axios.interceptors.response.use(interceptor);
       }

--- a/test/ts-retrofit.test.ts
+++ b/test/ts-retrofit.test.ts
@@ -379,12 +379,15 @@ describe("Test ts-retrofit.", () => {
 
   test("Test Interceptor Abstract Class", async () => {
     class AddHeaderInterceptor extends RequestInterceptor {
+
+      role = 'interceptor';
+
       onFulfilled(config: AxiosRequestConfig) {
         switch (config.method) {
           case 'get':
           case 'GET':
             if (typeof config.headers?.get === 'object') {
-              config.headers.get['X-Role'] = 'interceptor';
+              config.headers.get['X-Role'] = this.role;
             }
             break;
 


### PR DESCRIPTION
在设置Interceptor的时候如果不绑定Interceptor实例的话会出现如下报错：
```typescript
// 这种情况下会报错：“TypeError: Cannot read property 'xxx' of undefined”
this.axios.interceptors.request.use(interceptor.onFulfilled, interceptor.onRejected);
// 绑定之后就不会了，暂不明确Axios调用Interceptor的方式，可能直接apply了，this好像直接默认了undefined
this.axios.interceptors.request.use(interceptor.onFulfilled.bind(interceptor), interceptor.onRejected.bind(interceptor));

```