### PR TITLE
Proposition - Inline response body to returning object 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 | Statements | Branches | Functions | Lines |
 | -----------|----------|-----------|-------|
-| ![Statements](https://img.shields.io/badge/Coverage-96.07%25-brightgreen.svg "Make me better!") | ![Branches](https://img.shields.io/badge/Coverage-85.84%25-yellow.svg "Make me better!") | ![Functions](https://img.shields.io/badge/Coverage-87.85%25-yellow.svg "Make me better!") | ![Lines](https://img.shields.io/badge/Coverage-96.33%25-brightgreen.svg "Make me better!") |
+| ![Statements](https://img.shields.io/badge/Coverage-96.03%25-brightgreen.svg "Make me better!") | ![Branches](https://img.shields.io/badge/Coverage-85.59%25-yellow.svg "Make me better!") | ![Functions](https://img.shields.io/badge/Coverage-87.85%25-yellow.svg "Make me better!") | ![Lines](https://img.shields.io/badge/Coverage-96.28%25-brightgreen.svg "Make me better!") |
 
 > A declarative and [axios](https://github.com/axios/axios) based retrofit implementation for JavaScript and TypeScript.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 | Statements | Branches | Functions | Lines |
 | -----------|----------|-----------|-------|
-| ![Statements](https://img.shields.io/badge/Coverage-96.03%25-brightgreen.svg "Make me better!") | ![Branches](https://img.shields.io/badge/Coverage-85.59%25-yellow.svg "Make me better!") | ![Functions](https://img.shields.io/badge/Coverage-87.85%25-yellow.svg "Make me better!") | ![Lines](https://img.shields.io/badge/Coverage-96.28%25-brightgreen.svg "Make me better!") |
+| ![Statements](https://img.shields.io/badge/Coverage-96.07%25-brightgreen.svg "Make me better!") | ![Branches](https://img.shields.io/badge/Coverage-85.84%25-yellow.svg "Make me better!") | ![Functions](https://img.shields.io/badge/Coverage-87.85%25-yellow.svg "Make me better!") | ![Lines](https://img.shields.io/badge/Coverage-96.33%25-brightgreen.svg "Make me better!") |
 
 > A declarative and [axios](https://github.com/axios/axios) based retrofit implementation for JavaScript and TypeScript.
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![build status](https://travis-ci.org/nullcc/ts-retrofit.svg?branch=master)](https://travis-ci.org/nullcc/ts-retrofit)
 [![](https://img.shields.io/npm/dm/ts-retrofit.svg?style=flat)](https://www.npmjs.org/package/ts-retrofit)
 
-| Statements                               | Branches                                 | Functions                                | Lines                                    |
-| ---------------------------------------- | ---------------------------------------- | ---------------------------------------- | ---------------------------------------- |
-| ![Statements](https://img.shields.io/badge/Coverage-98.99%25-brightgreen.svg "Make me better!") | ![Branches](https://img.shields.io/badge/Coverage-83.87%25-yellow.svg "Make me better!") | ![Functions](https://img.shields.io/badge/Coverage-98.67%25-brightgreen.svg "Make me better!") | ![Lines](https://img.shields.io/badge/Coverage-98.99%25-brightgreen.svg "Make me better!") |
+| Statements | Branches | Functions | Lines |
+| -----------|----------|-----------|-------|
+| ![Statements](https://img.shields.io/badge/Coverage-96.03%25-brightgreen.svg "Make me better!") | ![Branches](https://img.shields.io/badge/Coverage-85.59%25-yellow.svg "Make me better!") | ![Functions](https://img.shields.io/badge/Coverage-87.85%25-yellow.svg "Make me better!") | ![Lines](https://img.shields.io/badge/Coverage-96.28%25-brightgreen.svg "Make me better!") |
 
-> A declarative and axios based retrofit implementation for JavaScript and TypeScript.
+> A declarative and [axios](https://github.com/axios/axios) based retrofit implementation for JavaScript and TypeScript.
 
 ## Install
 

--- a/src/baseService.ts
+++ b/src/baseService.ts
@@ -17,7 +17,7 @@ export interface Response<T = any> extends AxiosResponse<T> {
 export type InlinedResponse<T = any, R = any> = Readonly<T> & WithInternalResponseField<R>;
 export type InlinedResponseArray<T = any, R = any> = Array<InlinedResponse<T>> & WithInternalResponseField<R>;
 
-export type ApiResponse<T> = T extends any[] ? Promise<InlinedResponseArray<T[number]>> : Promise<InlinedResponse<T>>;
+export type ApiResponse<T> = Promise<T extends any[] ? InlinedResponseArray<T[number]> : InlinedResponse<T>>;
 
 export const STUB_RESPONSE = <T>() => ({} as T);
 

--- a/test/fixture/json-placeholder-fixtures.ts
+++ b/test/fixture/json-placeholder-fixtures.ts
@@ -26,5 +26,5 @@ export class TodosService extends BaseService {
     public async getSingle(@Path("id") id: number): ApiResponse<Todo> { return STUB_RESPONSE(); }
 
     @GET(URL_DOES_NOT_EXIST)
-    public async getForError(): ApiResponse<unknown> { return STUB_RESPONSE(); }
+    public async getForError(): ApiResponse<never> { return STUB_RESPONSE(); }
 }

--- a/test/fixture/json-placeholder-fixtures.ts
+++ b/test/fixture/json-placeholder-fixtures.ts
@@ -1,0 +1,22 @@
+import {BasePath, BaseService, GET, Path, ReducedResponse, ApiResponse, STUB_RESPONSE} from "../../src";
+export const JSON_PLACEHOLDER_ENDPOINT = `https://jsonplaceholder.typicode.com`;
+export const URL_DOES_NOT_EXIST = `/does-not-exist`;
+
+export interface Todo {
+    "userId": number;
+    "id": number;
+    "title": string;
+    "completed": boolean;
+}
+
+@BasePath("/todos")
+export class TodosService extends BaseService {
+    @GET("/")
+    public async getAll(): ApiResponse<Todo[]> { return STUB_RESPONSE(); }
+
+    @GET("/{userId}")
+    public async getSingle(@Path("userId") userId: number): ApiResponse<Todo> { return STUB_RESPONSE(); }
+
+    @GET(URL_DOES_NOT_EXIST)
+    public async getForError(): ApiResponse<never> { return STUB_RESPONSE(); }
+}

--- a/test/fixture/json-placeholder-fixtures.ts
+++ b/test/fixture/json-placeholder-fixtures.ts
@@ -22,8 +22,8 @@ export class TodosService extends BaseService {
     @GET("/")
     public async getAll(): ApiResponse<Todo[]> { return STUB_RESPONSE(); }
 
-    @GET("/{userId}")
-    public async getSingle(@Path("userId") userId: number): ApiResponse<Todo> { return STUB_RESPONSE(); }
+    @GET("/{id}")
+    public async getSingle(@Path("id") id: number): ApiResponse<Todo> { return STUB_RESPONSE(); }
 
     @GET(URL_DOES_NOT_EXIST)
     public async getForError(): ApiResponse<unknown> { return STUB_RESPONSE(); }

--- a/test/fixture/json-placeholder-fixtures.ts
+++ b/test/fixture/json-placeholder-fixtures.ts
@@ -1,4 +1,12 @@
-import {BasePath, BaseService, GET, Path, ReducedResponse, ApiResponse, STUB_RESPONSE} from "../../src";
+import {
+    BasePath,
+    BaseService,
+    GET,
+    Path,
+    InlinedResponse,
+    ApiResponse,
+    STUB_RESPONSE,
+} from "../../src";
 export const JSON_PLACEHOLDER_ENDPOINT = `https://jsonplaceholder.typicode.com`;
 export const URL_DOES_NOT_EXIST = `/does-not-exist`;
 
@@ -18,5 +26,5 @@ export class TodosService extends BaseService {
     public async getSingle(@Path("userId") userId: number): ApiResponse<Todo> { return STUB_RESPONSE(); }
 
     @GET(URL_DOES_NOT_EXIST)
-    public async getForError(): ApiResponse<never> { return STUB_RESPONSE(); }
+    public async getForError(): ApiResponse<unknown> { return STUB_RESPONSE(); }
 }

--- a/test/fixture/json-placeholder-fixtures.ts
+++ b/test/fixture/json-placeholder-fixtures.ts
@@ -3,8 +3,6 @@ import {
     BaseService,
     GET,
     Path,
-    InlinedResponse,
-    ApiResponse,
     STUB_RESPONSE,
 } from "../../src";
 export const JSON_PLACEHOLDER_ENDPOINT = `https://jsonplaceholder.typicode.com`;
@@ -20,11 +18,11 @@ export interface Todo {
 @BasePath("/todos")
 export class TodosService extends BaseService {
     @GET("/")
-    public async getAll(): ApiResponse<Todo[]> { return STUB_RESPONSE(); }
+    public async getAll(): Promise<Todo[]> { return STUB_RESPONSE(); }
 
     @GET("/{id}")
-    public async getSingle(@Path("id") id: number): ApiResponse<Todo> { return STUB_RESPONSE(); }
+    public async getSingle(@Path("id") id: number): Promise<Todo> { return STUB_RESPONSE(); }
 
     @GET(URL_DOES_NOT_EXIST)
-    public async getForError(): ApiResponse<never> { return STUB_RESPONSE(); }
+    public async getForError(): Promise<never> { return STUB_RESPONSE(); }
 }

--- a/test/ts-retrofit.test.ts
+++ b/test/ts-retrofit.test.ts
@@ -531,38 +531,29 @@ describe("Test ts-retrofit.", () => {
   });
 
   describe("Inlined response",  () => {
-    test("Get all", async () => {
-      const todoService = new ServiceBuilder()
+    let todoService: TodosService;
+
+    beforeEach(() => {
+      todoService = new ServiceBuilder()
           .setEndpoint(JSON_PLACEHOLDER_ENDPOINT)
           .withInlinedResponse()
           .build(TodosService);
+    });
 
+    test("Get all", async () => {
       const todo = await todoService.getSingle(1);
       expect(todo.id).toBe(1);
-      expect(todo.__response.config.url).toEqual(`${JSON_PLACEHOLDER_ENDPOINT}/todos/1`);
     });
 
     test("Array", async () => {
-      const todoService = new ServiceBuilder()
-          .setEndpoint(JSON_PLACEHOLDER_ENDPOINT)
-          .withInlinedResponse()
-          .build(TodosService);
-
       const todos = await todoService.getAll();
       expect(todos).not.toHaveLength(0);
 
-      const singleTodo = todos[0];
-      expect(singleTodo.id).toBe(1);
-
-      expect(todos.__response.config.url).toEqual(`${JSON_PLACEHOLDER_ENDPOINT}/todos/`);
+      expect(todos.find((e) => e.id === 1)?.id).toBe(1);
+      expect(todos[0].id).toBe(1);
     });
 
     test("Url not found", async () => {
-      const todoService = new ServiceBuilder()
-          .setEndpoint(JSON_PLACEHOLDER_ENDPOINT)
-          .withInlinedResponse()
-          .build(TodosService);
-
       try {
         await todoService.getForError();
       } catch (err) {

--- a/test/ts-retrofit.test.ts
+++ b/test/ts-retrofit.test.ts
@@ -542,6 +542,21 @@ describe("Test ts-retrofit.", () => {
       expect(todo.__response.config.url).toEqual(`${JSON_PLACEHOLDER_ENDPOINT}/todos/1`);
     });
 
+    test("Array", async () => {
+      const todoService = new ServiceBuilder()
+          .setEndpoint(JSON_PLACEHOLDER_ENDPOINT)
+          .withInlinedResponse()
+          .build(TodosService);
+
+      const todos = await todoService.getAll();
+      expect(todos).not.toHaveLength(0);
+
+      const singleTodo = todos[0];
+      expect(singleTodo.id).toBe(1);
+
+      expect(todos.__response.config.url).toEqual(`${JSON_PLACEHOLDER_ENDPOINT}/todos/`);
+    });
+
     test("Url not found", async () => {
       const todoService = new ServiceBuilder()
           .setEndpoint(JSON_PLACEHOLDER_ENDPOINT)

--- a/test/ts-retrofit.test.ts
+++ b/test/ts-retrofit.test.ts
@@ -29,6 +29,7 @@ import {
   HttpMethodOptionsService,
 } from "./fixture/fixtures";
 import { DATA_CONTENT_TYPES, HttpContentType } from "../src/constants";
+import {JSON_PLACEHOLDER_ENDPOINT, TodosService, URL_DOES_NOT_EXIST} from "./fixture/json-placeholder-fixtures";
 
 declare module 'axios' {
   interface AxiosRequestConfig {
@@ -527,5 +528,33 @@ describe("Test ts-retrofit.", () => {
     const response = await service.ping();
     expect(response.config.url).toEqual(`${TEST_SERVER_ENDPOINT}/ping`);
     expect(response.data).toEqual({ result: "pong" });
+  });
+
+  describe("Inlined response",  () => {
+    test("Get all", async () => {
+      const todoService = new ServiceBuilder()
+          .setEndpoint(JSON_PLACEHOLDER_ENDPOINT)
+          .withInlinedResponse()
+          .build(TodosService);
+
+      const todo = await todoService.getSingle(1);
+      expect(todo.id).toBe(1);
+      expect(todo.__response.config.url).toEqual(`${JSON_PLACEHOLDER_ENDPOINT}/todos/1`);
+    });
+
+    test("Url not found", async () => {
+      const todoService = new ServiceBuilder()
+          .setEndpoint(JSON_PLACEHOLDER_ENDPOINT)
+          .withInlinedResponse()
+          .build(TodosService);
+
+      try {
+        await todoService.getForError();
+      } catch (err) {
+        expect(err.config.url).toEqual(`${JSON_PLACEHOLDER_ENDPOINT}/todos${URL_DOES_NOT_EXIST}`);
+        return;
+      }
+      fail("Exception expected");
+    });
   });
 });


### PR DESCRIPTION
**Problem:**
Extra call to `data` field from response object (example: `response.data.id`)
Idea: replace call `response.data.id` to `response.id`

**Details:**
I've noticed that most of the time, I'm expecting a correct response and don't need headers and other metadata.
Headers and other metadata of response are used only in intercepters or login/sign-up requests.

Typical usage:
```typescript
const whoami = await user.auth.api.whoami();
const profile = await user.profiles.api.getDetails();

expect(whoami.data.id).toBe(profile.data.id);
expect(whoami.data.username).toBe(profile.data.email);
```

I have to get data from the response but what I really want is the response body itself.

**Solution:**
Add method `withInlinedResponse` to a `ServiceBuilder`.
```typescript
const todoService = new ServiceBuilder()
          .setEndpoint(JSON_PLACEHOLDER_ENDPOINT)
          .withInlinedResponse()
          .build(TodosService);
```

This method will change the response type from `Promise<Response<Todo>>` to `Promise<Todo>`

Usage: 
```typescript
@GET("/")
public async getAll(): Promise<Todo[]> { return STUB_RESPONSE(); }

@GET("/{id}")
public async getSingle(@Path("id") id: number): Promise<Todo> { return STUB_RESPONSE(); }
```

So that you can use response body directly.

> Single object
```typescript
const todo = await todoService.getSingle(1);
expect(todo.id).toBe(1);
```

> For arrays:
```typescript
const todos = await todoService.getAll();
expect(todos).not.toHaveLength(0);
```